### PR TITLE
Add a server whitelist and an option to disable Voxy in singleplayer

### DIFF
--- a/src/main/java/me/imgrui/VoxyExtra.java
+++ b/src/main/java/me/imgrui/VoxyExtra.java
@@ -17,7 +17,7 @@ public class VoxyExtra implements ModInitializer {
     public static final boolean IsFlashbackLoaded = FabricLoader.getInstance().isModLoaded("flashback");
 	public static VoxyExtraConfig CONFIG;
 
-    public static boolean isDisabledByServerList;
+    public static boolean isVoxyDisabled;
 	public static volatile @Nullable String IP;
 
 	@Override

--- a/src/main/java/me/imgrui/VoxyExtra.java
+++ b/src/main/java/me/imgrui/VoxyExtra.java
@@ -17,7 +17,7 @@ public class VoxyExtra implements ModInitializer {
     public static final boolean IsFlashbackLoaded = FabricLoader.getInstance().isModLoaded("flashback");
 	public static VoxyExtraConfig CONFIG;
 
-    public static boolean isInBlacklist;
+    public static boolean isDisabledByServerList;
 	public static volatile @Nullable String IP;
 
 	@Override

--- a/src/main/java/me/imgrui/config/VoxyExtraConfig.java
+++ b/src/main/java/me/imgrui/config/VoxyExtraConfig.java
@@ -26,6 +26,8 @@ public class VoxyExtraConfig implements ConfigData {
     @ConfigEntry.Gui.Tooltip
     public List<String> serverWhitelistList = new ArrayList<>();
     @ConfigEntry.Gui.Excluded
+    public boolean disableInSingleplayer;
+    @ConfigEntry.Gui.Excluded
     public boolean lodMirror;
     @ConfigEntry.Gui.Tooltip(count = 2)
     public List<String> lodMirrorList = new ArrayList<>();

--- a/src/main/java/me/imgrui/config/VoxyExtraConfig.java
+++ b/src/main/java/me/imgrui/config/VoxyExtraConfig.java
@@ -22,6 +22,10 @@ public class VoxyExtraConfig implements ConfigData {
     @ConfigEntry.Gui.Tooltip
     public List<String> serverBlacklistList = new ArrayList<>();
     @ConfigEntry.Gui.Excluded
+    public boolean serverWhitelist;
+    @ConfigEntry.Gui.Tooltip
+    public List<String> serverWhitelistList = new ArrayList<>();
+    @ConfigEntry.Gui.Excluded
     public boolean lodMirror;
     @ConfigEntry.Gui.Tooltip(count = 2)
     public List<String> lodMirrorList = new ArrayList<>();

--- a/src/main/java/me/imgrui/config/VoxyExtraStorage.java
+++ b/src/main/java/me/imgrui/config/VoxyExtraStorage.java
@@ -44,6 +44,14 @@ public class VoxyExtraStorage {
         config().serverBlacklist = serverBlacklist;
     }
 
+    public boolean getServerWhitelist() {
+        return config().serverWhitelist;
+    }
+
+    public void setServerWhitelist(boolean serverWhitelist) {
+        config().serverWhitelist = serverWhitelist;
+    }
+
     public boolean getLodMirror() {
         return config().lodMirror;
     }

--- a/src/main/java/me/imgrui/config/VoxyExtraStorage.java
+++ b/src/main/java/me/imgrui/config/VoxyExtraStorage.java
@@ -52,6 +52,14 @@ public class VoxyExtraStorage {
         config().serverWhitelist = serverWhitelist;
     }
 
+    public boolean getDisableInSingleplayer() {
+        return config().disableInSingleplayer;
+    }
+
+    public void setDisableInSingleplayer(boolean disableInSingleplayer) {
+        config().disableInSingleplayer = disableInSingleplayer;
+    }
+
     public boolean getLodMirror() {
         return config().lodMirror;
     }

--- a/src/main/java/me/imgrui/config/sodium/VoxyExtraConfigBuilder.java
+++ b/src/main/java/me/imgrui/config/sodium/VoxyExtraConfigBuilder.java
@@ -78,6 +78,14 @@ public class VoxyExtraConfigBuilder implements ConfigEntryPoint {
                                 .setDefaultValue(false)
                 )
                 .addOption(
+                        builder.createBooleanOption(Identifier.parse("voxy-extra:serverwhitelist"))
+                                .setName(Component.translatable("text.autoconfig.voxy-extra.option.serverWhitelist"))
+                                .setTooltip(Component.translatable("text.autoconfig.voxy-extra.option.serverWhitelist.@Tooltip"))
+                                .setStorageHandler(this.handler)
+                                .setBinding(this.storage::setServerWhitelist, this.storage::getServerWhitelist)
+                                .setDefaultValue(false)
+                )
+                .addOption(
                         builder.createBooleanOption(Identifier.parse("voxy-extra:redirectlod"))
                                 .setName(Component.translatable("text.autoconfig.voxy-extra.option.lodMirror"))
                                 .setTooltip(Component.translatable("text.autoconfig.voxy-extra.option.lodMirror.@Tooltip"))

--- a/src/main/java/me/imgrui/config/sodium/VoxyExtraConfigBuilder.java
+++ b/src/main/java/me/imgrui/config/sodium/VoxyExtraConfigBuilder.java
@@ -86,6 +86,14 @@ public class VoxyExtraConfigBuilder implements ConfigEntryPoint {
                                 .setDefaultValue(false)
                 )
                 .addOption(
+                        builder.createBooleanOption(Identifier.parse("voxy-extra:disableinsingleplayer"))
+                                .setName(Component.translatable("text.autoconfig.voxy-extra.option.disableInSingleplayer"))
+                                .setTooltip(Component.translatable("text.autoconfig.voxy-extra.option.disableInSingleplayer.@Tooltip"))
+                                .setStorageHandler(this.handler)
+                                .setBinding(this.storage::setDisableInSingleplayer, this.storage::getDisableInSingleplayer)
+                                .setDefaultValue(false)
+                )
+                .addOption(
                         builder.createBooleanOption(Identifier.parse("voxy-extra:redirectlod"))
                                 .setName(Component.translatable("text.autoconfig.voxy-extra.option.lodMirror"))
                                 .setTooltip(Component.translatable("text.autoconfig.voxy-extra.option.lodMirror.@Tooltip"))

--- a/src/main/java/me/imgrui/mixin/minecraft/MinecraftMixin.java
+++ b/src/main/java/me/imgrui/mixin/minecraft/MinecraftMixin.java
@@ -13,11 +13,11 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(value = Minecraft.class)
 public class MinecraftMixin {
     @Inject(method = "disconnect(Lnet/minecraft/client/gui/screens/Screen;ZZ)V", at = @At("HEAD"))
-    public void voxyExtra$handleBlacklist(Screen screen, boolean keepResourcePacks, boolean stopSound, CallbackInfo ci) {
-        if (VoxyExtra.isInBlacklist) {
+    public void voxyExtra$handleServerList(Screen screen, boolean keepResourcePacks, boolean stopSound, CallbackInfo ci) {
+        if (VoxyExtra.isDisabledByServerList) {
             VoxyConfig.CONFIG.enabled = true;
             IrisUtil.reload();
         }
-        VoxyExtra.isInBlacklist = false;
+        VoxyExtra.isDisabledByServerList = false;
     }
 }

--- a/src/main/java/me/imgrui/mixin/minecraft/MinecraftMixin.java
+++ b/src/main/java/me/imgrui/mixin/minecraft/MinecraftMixin.java
@@ -14,10 +14,10 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public class MinecraftMixin {
     @Inject(method = "disconnect(Lnet/minecraft/client/gui/screens/Screen;ZZ)V", at = @At("HEAD"))
     public void voxyExtra$handleServerList(Screen screen, boolean keepResourcePacks, boolean stopSound, CallbackInfo ci) {
-        if (VoxyExtra.isDisabledByServerList) {
+        if (VoxyExtra.isVoxyDisabled) {
             VoxyConfig.CONFIG.enabled = true;
             IrisUtil.reload();
         }
-        VoxyExtra.isDisabledByServerList = false;
+        VoxyExtra.isVoxyDisabled = false;
     }
 }

--- a/src/main/java/me/imgrui/mixin/voxy/VoxyCommonMixin.java
+++ b/src/main/java/me/imgrui/mixin/voxy/VoxyCommonMixin.java
@@ -8,31 +8,40 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import net.minecraft.client.Minecraft;
 
 @Mixin(value = VoxyCommon.class, remap = false)
 public class VoxyCommonMixin {
     @Inject(method = "createInstance", at = @At("HEAD"), cancellable = true)
     private static void voxyExtra$serverListCheck(CallbackInfo ci) {
         if (VoxyConfig.CONFIG.enabled && !VoxyExtra.isDisabledByServerList) {
+            Minecraft mc = Minecraft.getInstance();
+            boolean isSingleplayer = mc != null && mc.isLocalServer();            
+            boolean disableForSingleplayer = isSingleplayer && VoxyExtra.CONFIG.disableInSingleplayer;
+
+            boolean isBlacklisted = false;
+            boolean isNotWhitelisted = false;
             String ip = VoxyExtra.IP;
-            
-            if (ip != null) {
-                boolean isBlacklisted = VoxyExtra.CONFIG.serverBlacklist && VoxyExtra.CONFIG.serverBlacklistList.contains(ip);
-                boolean isNotWhitelisted = VoxyExtra.CONFIG.serverWhitelist && !VoxyExtra.CONFIG.serverWhitelistList.contains(ip);
 
-                if (isBlacklisted) {
-                    VoxyExtra.LOGGER.warn("[Voxy Extra] Server {} is blacklisted, disabling Voxy", ip);
-                } else if (isNotWhitelisted) {
-                    VoxyExtra.LOGGER.warn("[Voxy Extra] Server {} is not whitelisted, disabling Voxy", ip);
-                }
+            if (ip != null && !isSingleplayer) {
+                isBlacklisted = VoxyExtra.CONFIG.serverBlacklist && VoxyExtra.CONFIG.serverBlacklistList.contains(ip);
+                isNotWhitelisted = VoxyExtra.CONFIG.serverWhitelist && !VoxyExtra.CONFIG.serverWhitelistList.contains(ip);
+            }
 
-                if (isBlacklisted || isNotWhitelisted) {
-                    VoxyConfig.CONFIG.enabled = false;
-                    ci.cancel();
-                    IrisUtil.reload();
-                    VoxyExtra.isDisabledByServerList = true;
-                    return;
-                }
+            if (disableForSingleplayer) {
+                VoxyExtra.LOGGER.warn("[Voxy Extra] Singleplayer is disabled, disabling Voxy");
+            } else if (isBlacklisted) {
+                VoxyExtra.LOGGER.warn("[Voxy Extra] Server {} is blacklisted, disabling Voxy", ip);
+            } else if (isNotWhitelisted) {
+                VoxyExtra.LOGGER.warn("[Voxy Extra] Server {} is not whitelisted, disabling Voxy", ip);
+            }
+
+            if (disableForSingleplayer || isBlacklisted || isNotWhitelisted) {
+                VoxyConfig.CONFIG.enabled = false;
+                ci.cancel();
+                IrisUtil.reload();
+                VoxyExtra.isDisabledByServerList = true;
+                return;
             }
         }
         VoxyExtra.isDisabledByServerList = false;

--- a/src/main/java/me/imgrui/mixin/voxy/VoxyCommonMixin.java
+++ b/src/main/java/me/imgrui/mixin/voxy/VoxyCommonMixin.java
@@ -14,7 +14,7 @@ import net.minecraft.client.Minecraft;
 public class VoxyCommonMixin {
     @Inject(method = "createInstance", at = @At("HEAD"), cancellable = true)
     private static void voxyExtra$serverListCheck(CallbackInfo ci) {
-        if (VoxyConfig.CONFIG.enabled && !VoxyExtra.isDisabledByServerList) {
+        if (VoxyConfig.CONFIG.enabled && !VoxyExtra.isVoxyDisabled) {
             Minecraft mc = Minecraft.getInstance();
             boolean isSingleplayer = mc != null && mc.isLocalServer();            
             boolean disableForSingleplayer = isSingleplayer && VoxyExtra.CONFIG.disableInSingleplayer;
@@ -30,20 +30,20 @@ public class VoxyCommonMixin {
 
             if (disableForSingleplayer) {
                 VoxyExtra.LOGGER.warn("[Voxy Extra] Singleplayer is disabled, disabling Voxy");
-            } else if (isBlacklisted) {
-                VoxyExtra.LOGGER.warn("[Voxy Extra] Server {} is blacklisted, disabling Voxy", ip);
             } else if (isNotWhitelisted) {
                 VoxyExtra.LOGGER.warn("[Voxy Extra] Server {} is not whitelisted, disabling Voxy", ip);
+            } else if (isBlacklisted) {
+                VoxyExtra.LOGGER.warn("[Voxy Extra] Server {} is blacklisted, disabling Voxy", ip);
             }
 
             if (disableForSingleplayer || isBlacklisted || isNotWhitelisted) {
                 VoxyConfig.CONFIG.enabled = false;
                 ci.cancel();
                 IrisUtil.reload();
-                VoxyExtra.isDisabledByServerList = true;
+                VoxyExtra.isVoxyDisabled = true;
                 return;
             }
         }
-        VoxyExtra.isDisabledByServerList = false;
+        VoxyExtra.isVoxyDisabled = false;
     }
 }

--- a/src/main/java/me/imgrui/mixin/voxy/VoxyCommonMixin.java
+++ b/src/main/java/me/imgrui/mixin/voxy/VoxyCommonMixin.java
@@ -12,18 +12,29 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(value = VoxyCommon.class, remap = false)
 public class VoxyCommonMixin {
     @Inject(method = "createInstance", at = @At("HEAD"), cancellable = true)
-    private static void voxyExtra$serverBlacklist(CallbackInfo ci) {
-        if (VoxyExtra.CONFIG.serverBlacklist && VoxyConfig.CONFIG.enabled && !VoxyExtra.isInBlacklist) {
-            var IP = VoxyExtra.IP;
-            if (IP != null && VoxyExtra.CONFIG.serverBlacklistList.contains(IP)) {
-                VoxyConfig.CONFIG.enabled = false;
-                ci.cancel();
-                IrisUtil.reload();
-                VoxyExtra.isInBlacklist = true;
-                VoxyExtra.LOGGER.warn("[Voxy Extra] Server {} is blacklisted, disabling Voxy", IP);
-                return;
+    private static void voxyExtra$serverListCheck(CallbackInfo ci) {
+        if (VoxyConfig.CONFIG.enabled && !VoxyExtra.isDisabledByServerList) {
+            String ip = VoxyExtra.IP;
+            
+            if (ip != null) {
+                boolean isBlacklisted = VoxyExtra.CONFIG.serverBlacklist && VoxyExtra.CONFIG.serverBlacklistList.contains(ip);
+                boolean isNotWhitelisted = VoxyExtra.CONFIG.serverWhitelist && !VoxyExtra.CONFIG.serverWhitelistList.contains(ip);
+
+                if (isBlacklisted) {
+                    VoxyExtra.LOGGER.warn("[Voxy Extra] Server {} is blacklisted, disabling Voxy", ip);
+                } else if (isNotWhitelisted) {
+                    VoxyExtra.LOGGER.warn("[Voxy Extra] Server {} is not whitelisted, disabling Voxy", ip);
+                }
+
+                if (isBlacklisted || isNotWhitelisted) {
+                    VoxyConfig.CONFIG.enabled = false;
+                    ci.cancel();
+                    IrisUtil.reload();
+                    VoxyExtra.isDisabledByServerList = true;
+                    return;
+                }
             }
         }
-        VoxyExtra.isInBlacklist = false;
+        VoxyExtra.isDisabledByServerList = false;
     }
 }

--- a/src/main/resources/assets/voxy-extra/lang/en_us.json
+++ b/src/main/resources/assets/voxy-extra/lang/en_us.json
@@ -25,6 +25,9 @@
   "text.autoconfig.voxy-extra.option.serverWhitelistList": "Whitelisted servers",
   "text.autoconfig.voxy-extra.option.serverWhitelistList.@Tooltip": "Each field represents a single server.",
 
+  "text.autoconfig.voxy-extra.option.disableInSingleplayer": "Disable in Singleplayer",
+  "text.autoconfig.voxy-extra.option.disableInSingleplayer.@Tooltip": "Automatically disables Voxy when playing in a local singleplayer world.",
+
   "text.autoconfig.voxy-extra.option.lodMirror": "LoD Mirror",
   "text.autoconfig.voxy-extra.option.lodMirror.@Tooltip": "Allows setting one LoD storage for multiple servers. Add in Cloth Config.",
 

--- a/src/main/resources/assets/voxy-extra/lang/en_us.json
+++ b/src/main/resources/assets/voxy-extra/lang/en_us.json
@@ -20,7 +20,7 @@
   "text.autoconfig.voxy-extra.option.serverBlacklistList.@Tooltip": "Each field represents a single server.",
 
   "text.autoconfig.voxy-extra.option.serverWhitelist": "Server Whitelist",
-  "text.autoconfig.voxy-extra.option.serverWhitelist.@Tooltip": "Allows whitelisting servers to only enable Voxy in them. Add in Cloth Config.",
+  "text.autoconfig.voxy-extra.option.serverWhitelist.@Tooltip": "Allows whitelisting servers to enable Voxy only on them. Add in Cloth Config.",
 
   "text.autoconfig.voxy-extra.option.serverWhitelistList": "Whitelisted servers",
   "text.autoconfig.voxy-extra.option.serverWhitelistList.@Tooltip": "Each field represents a single server.",

--- a/src/main/resources/assets/voxy-extra/lang/en_us.json
+++ b/src/main/resources/assets/voxy-extra/lang/en_us.json
@@ -19,6 +19,12 @@
   "text.autoconfig.voxy-extra.option.serverBlacklistList": "Blacklisted servers",
   "text.autoconfig.voxy-extra.option.serverBlacklistList.@Tooltip": "Each field represents a single server.",
 
+  "text.autoconfig.voxy-extra.option.serverWhitelist": "Server Whitelist",
+  "text.autoconfig.voxy-extra.option.serverWhitelist.@Tooltip": "Allows whitelisting servers to only enable Voxy in them. Add in Cloth Config.",
+
+  "text.autoconfig.voxy-extra.option.serverWhitelistList": "Whitelisted servers",
+  "text.autoconfig.voxy-extra.option.serverWhitelistList.@Tooltip": "Each field represents a single server.",
+
   "text.autoconfig.voxy-extra.option.lodMirror": "LoD Mirror",
   "text.autoconfig.voxy-extra.option.lodMirror.@Tooltip": "Allows setting one LoD storage for multiple servers. Add in Cloth Config.",
 


### PR DESCRIPTION
This PR adds a server whitelist alongside the blacklist, and adds an option to disable Voxy for singleplayer worlds.

<img width="648" height="556" alt="image" src="https://github.com/user-attachments/assets/9a327f50-0f56-4738-9901-616d253b997a" />

<img width="1063" height="848" alt="image" src="https://github.com/user-attachments/assets/6ce212f5-2909-45d1-a547-4ef7379baefe" />

This could for example be useful for modpack distributors so Voxy is only enabled on the server made for that modpack, and so Voxy doesn't start generating all the chunks in singleplayer or on other servers to keep players' instance sizes small.
This PR also does not change any default behaviour of the mod (to my knowledge).

It built successfully with Oracle GraalVM 25.0.3+9.1 on Windows 11. Note: it doesn't include an updated `ru_ru.json` because I don't speak Russian.